### PR TITLE
Remove Gitab token refresh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   app:
     << : *restart_policy
-    image: buddy/repman:1.3.4
+    image: buddy/repman:1.4.0
     sysctls:
       net.core.somaxconn: 2048
     command: >
@@ -37,7 +37,7 @@ services:
 
   consumer:
     << : *restart_policy
-    image: buddy/repman:1.3.4
+    image: buddy/repman:1.4.0
     command: ['bin/console', 'messenger:consume', 'async', '--limit=500']
     env_file: .env.docker
     volumes:
@@ -48,7 +48,7 @@ services:
 
   cron:
     << : *restart_policy
-    image: buddy/repman:1.3.4
+    image: buddy/repman:1.4.0
     command: ['crond', '-f', '-L', '/app/var/log/cron.log']
     env_file: .env.docker
     volumes:

--- a/src/Entity/User/OAuthToken.php
+++ b/src/Entity/User/OAuthToken.php
@@ -87,6 +87,11 @@ class OAuthToken
         return $this->type() === $type;
     }
 
+    public function expiresAt(): ?\DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
     public function accessToken(UserOAuthTokenRefresher $tokenRefresher): string
     {
         if ($this->expiresAt !== null && (new \DateTimeImmutable()) > $this->expiresAt->modify('-1 min')) {
@@ -97,6 +102,9 @@ class OAuthToken
             try {
                 $newToken = $tokenRefresher->refresh($this->type, $this->refreshToken);
                 $this->accessToken = $newToken->token();
+                if ($newToken->getRefreshToken() !== null) {
+                    $this->refreshToken = $newToken->getRefreshToken();
+                }
                 $this->expiresAt = $newToken->expiresAt();
             } catch (\Throwable $exception) {
                 throw new \RuntimeException('An error occurred while refreshing the access token: '.$exception->getMessage());

--- a/src/Entity/User/OAuthToken.php
+++ b/src/Entity/User/OAuthToken.php
@@ -102,9 +102,6 @@ class OAuthToken
             try {
                 $newToken = $tokenRefresher->refresh($this->type, $this->refreshToken);
                 $this->accessToken = $newToken->token();
-                if ($newToken->getRefreshToken() !== null) {
-                    $this->refreshToken = $newToken->getRefreshToken();
-                }
                 $this->expiresAt = $newToken->expiresAt();
             } catch (\Throwable $exception) {
                 throw new \RuntimeException('An error occurred while refreshing the access token: '.$exception->getMessage());

--- a/src/Service/User/UserOAuthTokenProvider.php
+++ b/src/Service/User/UserOAuthTokenProvider.php
@@ -26,6 +26,10 @@ class UserOAuthTokenProvider
         $token = $this->repository->getById(Uuid::fromString($userId))->oauthToken($type);
         if ($token === null) {
             return null;
+        } else if ((new \DateTimeImmutable()) > $token->expiresAt()->modify('-1 min')) {
+            $this->em->remove($token);
+            $this->em->flush();
+            return null;
         }
 
         $accessToken = $token->accessToken($this->tokenRefresher);


### PR DESCRIPTION
Remove expired tokens on package manipulation to trigger a new one. Refresh needs the same callback URL and it might not be the case (refresh package, add new package, etc)